### PR TITLE
fix: resolve starter pack component resolution issue (#68)

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -235,12 +235,11 @@ export const initCommand = new Command("init")
           selectedWorkflows = nonInteractiveOpts.workflows || [];
           selectedHooks = nonInteractiveOpts.hooks || [];
           
-          // Add components from starter pack if we have one
-          if (packResult) {
-            selectedModes.push(...packResult.installed.modes.filter(mode => !selectedModes.includes(mode)));
-            selectedWorkflows.push(...packResult.installed.workflows.filter(workflow => !selectedWorkflows.includes(workflow)));
-            // Note: agents are handled differently - they're installed directly by the pack
-          }
+          // Note: Pack components are already installed by the starter pack installer,
+          // so we don't need to add them to selectedModes/selectedWorkflows.
+          // The applySetup method would try to install them again using the regular
+          // ComponentInstaller which looks in templates/, but pack components
+          // are only available in the pack's components/ directory.
         } else if (options.allRecommended) {
           selectedModes = projectInfo.suggestedModes;
           selectedWorkflows = projectInfo.suggestedWorkflows;


### PR DESCRIPTION
## Summary
- Fixes issue #68 where starter pack installation fails with "Component not found in templates" errors
- Components installed from starter packs were being re-processed by the regular ComponentInstaller which expected them in the main templates directory
- Pack components only exist in the pack's components directory, not in the main templates

## Changes Made

### 1. ComponentInstaller.installComponent improvements
- Added check for already installed components before template validation
- Enhanced validateDependencies to check installed locations before templates
- Added proper error handling for frontmatter parsing from installed components

### 2. Non-interactive initialization fix
- Removed redundant re-installation of pack components in `init.ts`
- Pack components are already installed by StarterPackManager, don't need reprocessing by InteractiveSetup.applySetup

## Test Plan
- [x] `zcc init --force --starter-pack frontend-react --non-interactive` now works correctly
- [x] All pack components (modes, workflows, agents) are properly installed
- [x] Regular component installation still works for template-based components
- [x] Component listing shows all installed components correctly

## Technical Details
The root cause was in the non-interactive initialization flow:
1. StarterPackManager successfully installs pack components from pack's components/ directory
2. init.ts added pack components to selectedModes/selectedWorkflows arrays  
3. InteractiveSetup.applySetup tried to re-install them using ComponentInstaller
4. ComponentInstaller looked for them in main templates/ directory (doesn't exist)
5. ENOENT error when trying to read template files

The fix prevents step 2-4 by recognizing that pack components are already installed and don't need reprocessing.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>