### PR TITLE
Fix Node.js DEP0190 deprecation warning in spawn calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "zcc",
+  "name": "z-claude-code",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "zcc",
+      "name": "z-claude-code",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "MIT",

--- a/src/commands/__tests__/edit.test.ts
+++ b/src/commands/__tests__/edit.test.ts
@@ -138,7 +138,7 @@ describe('Edit Command', () => {
       // Wait for async operations to complete
       await new Promise(resolve => setTimeout(resolve, 20));
       
-      expect(mockSpawn).toHaveBeenCalledWith('nano', ['/project/.zcc/modes/custom-mode.md'], {
+      expect(mockSpawn).toHaveBeenCalledWith('nano "/project/.zcc/modes/custom-mode.md"', [], {
         stdio: 'inherit',
         shell: true
       });
@@ -368,7 +368,7 @@ describe('Edit Command', () => {
 
       await editCommand.parseAsync(['mode', 'custom-mode', '--editor', 'vim'], { from: 'user' });
 
-      expect(mockSpawn).toHaveBeenCalledWith('vim', ['/project/.zcc/modes/custom-mode.md'], {
+      expect(mockSpawn).toHaveBeenCalledWith('vim "/project/.zcc/modes/custom-mode.md"', [], {
         stdio: 'inherit',
         shell: true
       });

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -269,7 +269,7 @@ async function editComponent(
   
   // Launch editor
   return new Promise((resolve, reject) => {
-    const editorProcess = spawn(editor, [component.path], {
+    const editorProcess = spawn(`${editor} "${component.path}"`, [], {
       stdio: 'inherit',
       shell: true
     });

--- a/src/lib/ScriptExecutor.ts
+++ b/src/lib/ScriptExecutor.ts
@@ -15,6 +15,7 @@ export interface ScriptContext {
   scriptPath: string;
   workingDirectory: string;  // Always project root
   env: Record<string, string>;  // Environment variables
+  stdin?: string;  // Optional stdin input
 }
 
 export interface ScriptResult {
@@ -101,6 +102,7 @@ export class ScriptExecutor {
         stripFinalNewline: false,
         windowsHide: true,
         preferLocal: true,
+        input: context.stdin,
       });
 
       const duration = Date.now() - startTime;

--- a/src/lib/hooks/HookExecutor.ts
+++ b/src/lib/hooks/HookExecutor.ts
@@ -139,11 +139,19 @@ export class HookExecutor {
       env.HOOK_PROMPT = context.prompt;
     }
 
+    // Prepare stdin data based on hook event and context
+    let stdin: string | undefined;
+    if (context.event === 'UserPromptSubmit' && context.prompt) {
+      // For UserPromptSubmit hooks, pass the prompt as JSON via stdin
+      stdin = JSON.stringify({ prompt: context.prompt });
+    }
+
     return {
       source,
       scriptPath,
       workingDirectory: context.projectRoot, // Always execute in project root
-      env
+      env,
+      stdin
     };
   }
 

--- a/src/lib/hooks/HookValidator.ts
+++ b/src/lib/hooks/HookValidator.ts
@@ -257,7 +257,7 @@ export class HookValidator {
    */
   private async checkCommandAvailable(command: string): Promise<boolean> {
     return new Promise((resolve) => {
-      const child = spawn('which', [command], {
+      const child = spawn(`which ${command}`, [], {
         stdio: 'ignore',
         shell: true
       });


### PR DESCRIPTION
## Summary
- Fixed Node.js DEP0190 deprecation warning that occurred when using spawn() with shell: true and an arguments array
- Improved hook script execution by adding proper stdin support for data passing
- Resolved timeout issues with acronym-expander hook

## Changes
1. **Fixed spawn() deprecation warning**: Updated all spawn() calls to concatenate command and arguments into a single string when using `shell: true` option
2. **Added stdin support**: Enhanced ScriptExecutor to support stdin data passing to scripts
3. **Improved hook data passing**: Modified HookExecutor to pass prompt data as JSON via stdin for UserPromptSubmit hooks
4. **Updated tests**: Adjusted test expectations to match the new spawn() call format

## Test Plan
- [x] Run `npm test` - all tests pass
- [x] Build project with `npm run build` - builds successfully
- [x] Test adding acronym-expander hook - no deprecation warnings or timeouts
- [x] Test edit command functionality - works correctly with quoted paths
- [x] Verify hook system works with `npm run dev init -- --force --non-interactive`

## Before
```
(node:95107) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities
⚠ Script execution timeout after 10000ms: acronym-expander
```

## After
```
✓ Created hook from template: acronym-expander
✓ Added hook from template: acronym-expander
```

🤖 Generated with [Claude Code](https://claude.ai/code)