### PR TITLE
fix: prevent duplicate hook registration in HookRegistry

### DIFF
--- a/src/lib/hooks/HookRegistry.ts
+++ b/src/lib/hooks/HookRegistry.ts
@@ -79,11 +79,19 @@ export class HookRegistry {
    * Now uses factory registry for dynamic hook creation
    */
   addHook(config: HookConfig): void {
+    // Check if hook with same ID already exists
+    const eventHooks = this.hooks.get(config.event) || [];
+    const existingHookIndex = eventHooks.findIndex(h => h.id === config.id);
+    
+    if (existingHookIndex !== -1) {
+      logger.debug(`Hook already registered: ${config.id} for event: ${config.event}, skipping duplicate`);
+      return;
+    }
+    
     // Use registered factory or fall back to base Hook class
     const HookClass = this.hookFactories.get(config.event) || Hook;
     const hook = new (HookClass as any)(config);
     
-    const eventHooks = this.hooks.get(config.event) || [];
     eventHooks.push(hook);
     
     // Sort by priority (higher priority first)


### PR DESCRIPTION
## Summary
Fixes #77 - Duplicate hook entries appear when listing hooks

## Problem
When running `zcc hook list`, the same hook (like "ZCC Routing Hook") would appear multiple times in the output. This was confusing for users and indicated an issue with hook registration.

## Root Cause
The issue occurred because hooks were being registered twice during initialization:
1. First via `generateBuiltinHooks()` which adds hooks directly to the registry
2. Then again via `loadHookDefinitions()` which loads the same hooks from saved JSON files

The `HookRegistry.addHook()` method had no deduplication logic, allowing the same hook to be added multiple times.

## Solution
Added deduplication logic to the `addHook()` method:
- Check if a hook with the same ID already exists before adding it
- Skip duplicate registrations with a debug log message
- This prevents the same hook from being registered multiple times

## Testing
Tested locally by:
1. Running `zcc init` in a test project
2. Running `zcc hook list`
3. Confirmed that each hook now appears only once in the output

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)