### PR TITLE
fix: prevent duplicate :* suffix in permission patterns

### DIFF
--- a/src/lib/hooks/PermissionGenerator.ts
+++ b/src/lib/hooks/PermissionGenerator.ts
@@ -91,7 +91,12 @@ export class PermissionGenerator {
                   const innerContent = tool.slice(5, -1); // Remove "Bash(" and ")"
                   if (innerContent.includes(":")) {
                     // Already has pattern like "sh:.zcc/scripts/mode-switch.sh"
-                    allowPermissions.add(`Bash(${innerContent}:*)`);
+                    // Check if it already ends with :* to avoid double suffix
+                    if (innerContent.endsWith(":*")) {
+                      allowPermissions.add(tool); // Already has :*, use as-is
+                    } else {
+                      allowPermissions.add(`Bash(${innerContent}:*)`);
+                    }
                   } else {
                     // Add :* for simple patterns
                     allowPermissions.add(`${tool}:*`);


### PR DESCRIPTION
## Summary
Fixes #79 - Permissions format inconsistency in settings.local.json

## Problem
The generated `.claude/settings.local.json` file had inconsistent permission patterns:
- Some entries had duplicate `:*:*` suffixes (malformed)
- Some entries had no suffix at all
- This inconsistency could cause permission issues in Claude Code

Example of the issue:
```json
"Bash(sh .zcc/scripts/mode-switch.sh)"      // No suffix
"Bash(sh .zcc/scripts/mode-switch.sh):*:*"  // Double suffix (malformed)
```

## Root Cause
In `PermissionGenerator.ts`, when processing allowed-tools from command frontmatter that already contained `:*`, the code was blindly appending another `:*` suffix, resulting in `:*:*`.

## Solution
Modified the permission generation logic to:
1. Check if a pattern already ends with `:*`
2. If it does, use it as-is without appending another suffix
3. Only append `:*` when the pattern doesn't already have it

## Result
Now the permissions are consistent:
```json
"Bash(sh .zcc/scripts/mode-switch.sh)"     // From command patterns
"Bash(sh .zcc/scripts/mode-switch.sh:*)"   // From allowed-tools (correct single :*)
```

## Testing
Tested by:
1. Running `zcc init --force --non-interactive`
2. Checking the generated `.claude/settings.local.json`
3. Confirming no more duplicate `:*:*` patterns appear

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)