### PR TITLE
fix: resolve component discovery bugs (#86)

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -50,10 +50,27 @@ export const listCommand = new Command('list')
       const core = new ZccCore(process.cwd());
       const status = await core.getStatus();
       
-      // Validate type filter
+      // Validate type filter and map singular forms to plural keys
       const validTypes: ComponentInfo['type'][] = ['mode', 'workflow', 'agent', 'script', 'hook', 'command', 'template'];
-      if (options.type && !validTypes.includes(options.type)) {
-        logger.error(`Invalid component type '${options.type}'. Valid types are: ${validTypes.join(', ')}`);
+      const typeMapping: { [key: string]: string } = {
+        'mode': 'modes',
+        'modes': 'modes',
+        'workflow': 'workflows', 
+        'workflows': 'workflows',
+        'agent': 'agents',
+        'agents': 'agents',
+        'script': 'scripts',
+        'scripts': 'scripts', 
+        'hook': 'hooks',
+        'hooks': 'hooks',
+        'command': 'commands',
+        'commands': 'commands',
+        'template': 'templates',
+        'templates': 'templates'
+      };
+      
+      if (options.type && !typeMapping[options.type]) {
+        logger.error(`Invalid component type '${options.type}'. Valid types are: ${validTypes.join(', ')} (plural forms also accepted)`);
         process.exit(1);
       }
       
@@ -77,7 +94,7 @@ export const listCommand = new Command('list')
         await showConflictingComponents(componentsByType, options.verbose || false);
       } else {
         await showComponents(componentsByType, {
-          typeFilter: options.type,
+          typeFilter: options.type ? typeMapping[options.type] || options.type : undefined,
           scopeFilter: options.scope,
           verbose: options.verbose || false,
           installedOnly: options.installed || false


### PR DESCRIPTION
## Summary
- Fix type filter bug in list command: now accepts both singular (mode) and plural (modes) forms  
- Add proper error messages for invalid component types
- Fix duplicate search results in add command by deduplicating fuzzy matches by name

## Technical Details

### Issue #86 Problems Fixed:

1. **Type filter bug in `list` command**: The `--type` option accepted singular forms (`mode`) but the internal logic expected plural forms (`modes`), causing filtering to fail.

2. **Duplicate search results in `add` command**: When the same component existed in multiple scopes (builtin, global, project), fuzzy matching would return multiple identical results instead of deduplicating by name.

### Changes Made:

1. **Enhanced type validation in `src/commands/list.ts`**:
   - Added `typeMapping` to convert both singular and plural forms to correct plural keys
   - Improved error messages to indicate both forms are accepted
   - Updated filtering logic to use mapped types

2. **Improved component search in `src/lib/ZccCore.ts`**:
   - Added deduplication logic in `findComponents()` method
   - Prioritizes higher-precedence scopes (project > global > builtin) when deduplicating
   - Maintains conflict information and source details for user experience
   - Preserves proper sorting by score, precedence, and name

## Test Plan
- [x] Type filter now works with both `--type mode` and `--type modes`
- [x] Invalid types show helpful error messages
- [x] Fuzzy search no longer shows duplicate results
- [x] Component precedence is properly maintained 
- [x] All existing unit tests pass
- [x] Manual testing confirms both commands work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)