### PR TITLE
feat: Add configuration schema validation command (#95)

### DIFF
--- a/src/commands/__tests__/config-validate.test.ts
+++ b/src/commands/__tests__/config-validate.test.ts
@@ -1,0 +1,206 @@
+import { configCommand } from '../config';
+import { logger } from '../../lib/logger';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+
+// Mock dependencies
+jest.mock('../../lib/logger');
+
+describe('config validate command', () => {
+  let tempDir: string;
+  const mockLogger = logger as jest.Mocked<typeof logger>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tempDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'zcc-test-'));
+    
+    // Create .zcc directory
+    fs.mkdirSync(path.join(tempDir, '.zcc'), { recursive: true });
+    
+    // Mock process.exit
+    process.exit = jest.fn() as any;
+  });
+
+  afterEach(() => {
+    // Clean up temp directory
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('validate subcommand', () => {
+    it('should validate a valid configuration', async () => {
+      // Create valid config
+      const validConfig = {
+        defaultMode: 'engineer',
+        preferredWorkflows: ['review'],
+        ui: {
+          colorOutput: true,
+          verboseLogging: false
+        }
+      };
+      
+      const configPath = path.join(tempDir, '.zcc', 'config.yaml');
+      fs.writeFileSync(configPath, yaml.dump(validConfig));
+      
+      // Change to temp directory
+      const originalCwd = process.cwd();
+      process.chdir(tempDir);
+      
+      try {
+        // Run validate command
+        await configCommand.parseAsync(['node', 'zcc', 'config', 'validate']);
+        
+        expect(mockLogger.success).toHaveBeenCalledWith('Configuration is valid!');
+        expect(process.exit).not.toHaveBeenCalled();
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('should report validation errors for invalid configuration', async () => {
+      // Create invalid config
+      const invalidConfig = {
+        defaultMode: 123, // Should be string
+        preferredWorkflows: 'review', // Should be array
+        ui: {
+          colorOutput: 'yes', // Should be boolean
+          verboseLogging: null // Should be boolean
+        }
+      };
+      
+      const configPath = path.join(tempDir, '.zcc', 'config.yaml');
+      fs.writeFileSync(configPath, yaml.dump(invalidConfig));
+      
+      // Change to temp directory
+      const originalCwd = process.cwd();
+      process.chdir(tempDir);
+      
+      try {
+        // Run validate command
+        await configCommand.parseAsync(['node', 'zcc', 'config', 'validate']);
+        
+        expect(mockLogger.error).toHaveBeenCalledWith('Configuration validation failed.');
+        expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Validation errors:'));
+        expect(process.exit).toHaveBeenCalledWith(1);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('should fix invalid configuration with --fix flag', async () => {
+      // Create invalid config
+      const invalidConfig = {
+        defaultMode: 123, // Will be fixed to 'engineer'
+        preferredWorkflows: 'review', // Will be fixed to []
+        ui: 'invalid' // Will be fixed to default object
+      };
+      
+      const configPath = path.join(tempDir, '.zcc', 'config.yaml');
+      fs.writeFileSync(configPath, yaml.dump(invalidConfig));
+      
+      // Change to temp directory
+      const originalCwd = process.cwd();
+      process.chdir(tempDir);
+      
+      try {
+        // Run validate command with --fix
+        await configCommand.parseAsync(['node', 'zcc', 'config', 'validate', '--fix']);
+        
+        expect(mockLogger.info).toHaveBeenCalledWith('\nAttempting to fix validation issues...');
+        expect(mockLogger.success).toHaveBeenCalledWith('Configuration issues have been fixed!');
+        
+        // Verify the config was actually fixed
+        const fixedContent = fs.readFileSync(configPath, 'utf-8');
+        const fixedConfig = yaml.load(fixedContent) as any;
+        
+        expect(fixedConfig.defaultMode).toBe('engineer');
+        expect(Array.isArray(fixedConfig.preferredWorkflows)).toBe(true);
+        expect(fixedConfig.ui).toEqual({
+          colorOutput: true,
+          verboseLogging: false
+        });
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('should handle missing configuration file', async () => {
+      // Don't create any config file
+      
+      // Change to temp directory
+      const originalCwd = process.cwd();
+      process.chdir(tempDir);
+      
+      try {
+        // Run validate command
+        await configCommand.parseAsync(['node', 'zcc', 'config', 'validate']);
+        
+        expect(mockLogger.error).toHaveBeenCalledWith('Configuration validation failed.');
+        expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Configuration file not found'));
+        expect(process.exit).toHaveBeenCalledWith(1);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('should validate global configuration with --global flag', async () => {
+      // Create global config directory
+      const globalDir = path.join(require('os').homedir(), '.zcc');
+      fs.mkdirSync(globalDir, { recursive: true });
+      
+      const globalConfig = {
+        defaultMode: 'architect',
+        preferredWorkflows: ['summarize']
+      };
+      
+      const globalConfigPath = path.join(globalDir, 'config.yaml');
+      fs.writeFileSync(globalConfigPath, yaml.dump(globalConfig));
+      
+      try {
+        // Run validate command with --global
+        await configCommand.parseAsync(['node', 'zcc', 'config', 'validate', '--global']);
+        
+        expect(mockLogger.success).toHaveBeenCalledWith('Configuration is valid!');
+      } finally {
+        // Clean up global config
+        if (fs.existsSync(globalConfigPath)) {
+          fs.unlinkSync(globalConfigPath);
+        }
+      }
+    });
+
+    it('should create default configuration with --fix when file is missing', async () => {
+      // Don't create any config file
+      
+      // Change to temp directory
+      const originalCwd = process.cwd();
+      process.chdir(tempDir);
+      
+      try {
+        // Run validate command with --fix
+        await configCommand.parseAsync(['node', 'zcc', 'config', 'validate', '--fix']);
+        
+        expect(mockLogger.info).toHaveBeenCalledWith('\nAttempting to fix validation issues...');
+        expect(mockLogger.success).toHaveBeenCalledWith('Configuration issues have been fixed!');
+        
+        // Verify default config was created
+        const configPath = path.join(tempDir, '.zcc', 'config.yaml');
+        expect(fs.existsSync(configPath)).toBe(true);
+        
+        const createdContent = fs.readFileSync(configPath, 'utf-8');
+        const createdConfig = yaml.load(createdContent) as any;
+        
+        expect(createdConfig.defaultMode).toBe('engineer');
+        expect(createdConfig.preferredWorkflows).toEqual([]);
+        expect(createdConfig.ui).toEqual({
+          colorOutput: true,
+          verboseLogging: false
+        });
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+  });
+});

--- a/src/lib/__tests__/configSchema.test.ts
+++ b/src/lib/__tests__/configSchema.test.ts
@@ -1,0 +1,307 @@
+import {
+  ZccConfigValidator,
+  HookConfigValidator,
+  AcronymConfigValidator,
+  ConfigSchemaRegistry
+} from '../configSchema';
+
+describe('ConfigSchema Validation', () => {
+  describe('ZccConfigValidator', () => {
+    const validator = new ZccConfigValidator();
+
+    it('should validate valid configuration', () => {
+      const config = {
+        defaultMode: 'engineer',
+        preferredWorkflows: ['review', 'summarize'],
+        customTemplateSources: ['/path/to/templates'],
+        integrations: {
+          github: { token: 'abc123' }
+        },
+        ui: {
+          colorOutput: true,
+          verboseLogging: false
+        },
+        components: {
+          modes: ['engineer', 'architect'],
+          workflows: ['review']
+        }
+      };
+
+      const result = validator.validate(config);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should reject invalid defaultMode type', () => {
+      const config = {
+        defaultMode: 123 // Should be string
+      };
+
+      const result = validator.validate(config);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Default mode must be a string');
+    });
+
+    it('should reject invalid preferredWorkflows type', () => {
+      const config = {
+        preferredWorkflows: 'review' // Should be array
+      };
+
+      const result = validator.validate(config);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Preferred workflows must be an array of strings');
+    });
+
+    it('should reject invalid UI settings', () => {
+      const config = {
+        ui: {
+          colorOutput: 'yes', // Should be boolean
+          verboseLogging: 1 // Should be boolean
+        }
+      };
+
+      const result = validator.validate(config);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('UI.colorOutput must be a boolean');
+      expect(result.errors).toContain('UI.verboseLogging must be a boolean');
+    });
+
+    it('should accept empty configuration', () => {
+      const config = {};
+      const result = validator.validate(config);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should validate partial configuration', () => {
+      const config = {
+        defaultMode: 'architect'
+      };
+      
+      const result = validator.validatePartial(config);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe('HookConfigValidator', () => {
+    const validator = new HookConfigValidator();
+
+    it('should validate valid hook configuration', () => {
+      const hook = {
+        id: 'my-hook',
+        name: 'My Hook',
+        description: 'A test hook',
+        event: 'UserPromptSubmit',
+        enabled: true,
+        command: 'echo "hello"',
+        args: ['arg1', 'arg2'],
+        env: { NODE_ENV: 'test' },
+        timeout: 5000,
+        continueOnError: false,
+        priority: 10,
+        matcher: {
+          type: 'regex',
+          pattern: '.*test.*',
+          confidence: 0.8
+        },
+        requirements: {
+          commands: ['node'],
+          env: ['NODE_ENV'],
+          files: ['.env']
+        }
+      };
+
+      const result = validator.validate(hook);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should require mandatory fields', () => {
+      const hook = {
+        description: 'Missing required fields'
+      };
+
+      const result = validator.validate(hook);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Hook id is required and must be a string');
+      expect(result.errors).toContain('Hook name is required and must be a string');
+      expect(result.errors).toContain('Hook command is required and must be a string');
+      expect(result.errors).toContain('Hook enabled is required and must be a boolean');
+    });
+
+    it('should validate hook event', () => {
+      const hook = {
+        id: 'test',
+        name: 'Test',
+        event: 'InvalidEvent', // Invalid
+        enabled: true,
+        command: 'echo test'
+      };
+
+      const result = validator.validate(hook);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Invalid hook event'))).toBe(true);
+    });
+
+    it('should validate matcher configuration', () => {
+      const hook = {
+        id: 'test',
+        name: 'Test',
+        event: 'PreToolUse',
+        enabled: true,
+        command: 'echo test',
+        matcher: {
+          type: 'invalid', // Invalid type
+          pattern: 'test'
+        }
+      };
+
+      const result = validator.validate(hook);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Invalid matcher type'))).toBe(true);
+    });
+
+    it('should validate confidence range', () => {
+      const hook = {
+        id: 'test',
+        name: 'Test',
+        event: 'PreToolUse',
+        enabled: true,
+        command: 'echo test',
+        matcher: {
+          type: 'fuzzy',
+          pattern: 'test',
+          confidence: 1.5 // Out of range
+        }
+      };
+
+      const result = validator.validate(hook);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Matcher confidence must be between 0 and 1');
+    });
+  });
+
+  describe('AcronymConfigValidator', () => {
+    const validator = new AcronymConfigValidator();
+
+    it('should validate valid acronym configuration', () => {
+      const config = {
+        version: '1.0.0',
+        acronyms: {
+          'zcc': 'zsh for Claude Code',
+          'apm': 'autonomous-project-manager'
+        },
+        settings: {
+          caseSensitive: false,
+          wholeWordOnly: true
+        }
+      };
+
+      const result = validator.validate(config);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should require acronyms object', () => {
+      const config = {
+        settings: {
+          caseSensitive: false,
+          wholeWordOnly: true
+        }
+      };
+
+      const result = validator.validate(config);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Acronyms must be an object');
+    });
+
+    it('should validate acronym values are strings', () => {
+      const config = {
+        acronyms: {
+          'test': 123 // Should be string
+        },
+        settings: {
+          caseSensitive: false,
+          wholeWordOnly: true
+        }
+      };
+
+      const result = validator.validate(config);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Acronym value for "test" must be a string');
+    });
+
+    it('should require settings object', () => {
+      const config = {
+        acronyms: {
+          'zcc': 'zsh for Claude Code'
+        }
+      };
+
+      const result = validator.validate(config);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Acronym settings must be an object');
+    });
+
+    it('should validate settings booleans', () => {
+      const config = {
+        acronyms: {
+          'zcc': 'zsh for Claude Code'
+        },
+        settings: {
+          caseSensitive: 'false', // Should be boolean
+          wholeWordOnly: 1 // Should be boolean
+        }
+      };
+
+      const result = validator.validate(config);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Settings.caseSensitive must be a boolean');
+      expect(result.errors).toContain('Settings.wholeWordOnly must be a boolean');
+    });
+  });
+
+  describe('ConfigSchemaRegistry', () => {
+    const registry = ConfigSchemaRegistry.getInstance();
+
+    it('should be a singleton', () => {
+      const registry2 = ConfigSchemaRegistry.getInstance();
+      expect(registry).toBe(registry2);
+    });
+
+    it('should provide access to validators', () => {
+      expect(registry.getZccConfigValidator()).toBeInstanceOf(ZccConfigValidator);
+      expect(registry.getHookConfigValidator()).toBeInstanceOf(HookConfigValidator);
+      expect(registry.getAcronymConfigValidator()).toBeInstanceOf(AcronymConfigValidator);
+    });
+
+    it('should validateAndThrow for invalid config', () => {
+      const invalidConfig = {
+        defaultMode: 123 // Invalid type
+      };
+
+      expect(() => {
+        registry.validateAndThrow(
+          registry.getZccConfigValidator(),
+          invalidConfig,
+          'Test Config'
+        );
+      }).toThrow('Test Config validation failed: Default mode must be a string');
+    });
+
+    it('should not throw for valid config', () => {
+      const validConfig = {
+        defaultMode: 'engineer'
+      };
+
+      expect(() => {
+        registry.validateAndThrow(
+          registry.getZccConfigValidator(),
+          validConfig,
+          'Test Config'
+        );
+      }).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implemented `zcc config validate` command for validating configuration files
- Added `--fix` flag to automatically repair common configuration issues
- Comprehensive validation for all configuration types (ZccConfig, HookConfig, AcronymConfig)

## Changes
### New Command
- **`config validate`**: Validates .zcc/config.yaml against JSON schema
- **`--global` flag**: Validates global configuration (~/.zcc/config.yaml)
- **`--fix` flag**: Automatically fixes common validation issues

### Validation Features
- **Type checking**: Ensures all fields have correct data types
- **Required fields**: Validates presence of mandatory configuration
- **Value constraints**: Checks ranges, enums, and format requirements
- **Nested validation**: Deep validation of complex objects

### Auto-fix Capabilities
- Creates default configuration if missing
- Corrects invalid type assignments
- Removes malformed entries
- Sets sensible defaults for missing fields

### Testing
- Comprehensive test suite for all validators
- Tests for validate command with various scenarios
- Tests for auto-fix functionality
- Edge case handling

## Implementation Details
The validation system uses:
1. **ConfigSchemaRegistry**: Central registry for all validators
2. **Typed validators**: Separate validators for each config type
3. **ValidationResult interface**: Consistent error/warning reporting
4. **Smart fix logic**: Context-aware configuration repairs

## Usage Examples
```bash
# Validate project configuration
zcc config validate

# Validate global configuration
zcc config validate --global

# Auto-fix validation issues
zcc config validate --fix

# Validate and fix global config
zcc config validate --global --fix
```

## Test Plan
- [x] Unit tests for all validators
- [x] Command integration tests
- [x] Auto-fix functionality tests
- [x] Edge case coverage
- [ ] Manual testing with real configs

## Related Issues
Fixes #95

🤖 Generated with [Claude Code](https://claude.ai/code)