### PR TITLE
fix: respect --force flag when regenerating hook settings

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -170,7 +170,7 @@ export const initCommand = new Command("init")
         // Generate hook infrastructure
         logger.space();
         logger.info("Generating Claude Code hook infrastructure...");
-        await hookManager.initialize();
+        await hookManager.initialize(forceFlag);
 
         // Generate custom commands
         logger.info("Generating Claude Code custom commands...");
@@ -298,7 +298,7 @@ export const initCommand = new Command("init")
       // Generate hook infrastructure
       logger.space();
       logger.info("Generating Claude Code hook infrastructure...");
-      await hookManager.initialize();
+      await hookManager.initialize(forceFlag);
 
       // Generate custom commands
       logger.info("Generating Claude Code custom commands...");


### PR DESCRIPTION
Fixes issue where `zcc init --force` would not fully regenerate `.claude/settings.local.json` hooks section when file already existed.

## Changes

- Update HookManager.initialize() to accept force parameter
- When force=true, completely replace hooks section instead of merging
- When force=false, preserve existing merge behavior
- Update init.ts callers to pass force flag

Fixes #119

Generated with [Claude Code](https://claude.ai/code)