### PR TITLE
feat: allow forcing color output

### DIFF
--- a/src/lib/__tests__/logger.test.ts
+++ b/src/lib/__tests__/logger.test.ts
@@ -1,4 +1,4 @@
-import { logger } from '../logger';
+import { logger, configureChalk } from '../logger';
 import { ZccError } from '../errors';
 
 describe('logger', () => {
@@ -161,8 +161,36 @@ describe('logger', () => {
     it('should clear progress line when TTY', () => {
       process.stdout.isTTY = true;
       logger.clearProgress();
-      
+
       expect(stdoutWriteSpy).toHaveBeenCalledWith('\r\x1b[K');
+    });
+  });
+
+  describe('color configuration', () => {
+    const ORIGINAL_ENV = process.env;
+
+    beforeEach(() => {
+      process.env = { ...ORIGINAL_ENV };
+      logger.setNoColor(false);
+    });
+
+    afterEach(() => {
+      process.env = ORIGINAL_ENV;
+      logger.setNoColor(false);
+      configureChalk();
+    });
+
+    it('should disable colors when NO_COLOR is set', () => {
+      process.env.NO_COLOR = '1';
+      const chalkInstance = configureChalk();
+      expect(chalkInstance.level).toBe(0);
+    });
+
+    it('should respect FORCE_COLOR even in CI', () => {
+      process.env.CI = '1';
+      process.env.FORCE_COLOR = '1';
+      const chalkInstance = configureChalk();
+      expect(chalkInstance.level).toBe(1);
     });
   });
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -8,22 +8,27 @@ let colorsDisabled = false;
 
 // Color detection logic
 function shouldDisableColors(): boolean {
-  // Check NO_COLOR environment variable (https://no-color.org)
-  if (process.env.NO_COLOR) {
+  // Explicit configuration always wins
+  if (colorsDisabled || process.env.NO_COLOR) {
     return true;
   }
-  
+
+  // Allow overriding automatic detection
+  if (process.env.FORCE_COLOR) {
+    return false;
+  }
+
   // Check CI environment
   if (process.env.CI) {
     return true;
   }
-  
+
   // Check if running in a TTY
   if (!process.stdout.isTTY) {
     return true;
   }
-  
-  return colorsDisabled;
+
+  return false;
 }
 
 // ANSI color codes for better terminal output


### PR DESCRIPTION
## Summary
- allow overriding color detection with `FORCE_COLOR`
- cover NO_COLOR/FORCE_COLOR behavior with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c460242bb48325b7d7d75d04802171